### PR TITLE
Fixes bug when processing doors, separates pin drawing

### DIFF
--- a/scripts/jquery.wayfinding.js
+++ b/scripts/jquery.wayfinding.js
@@ -297,6 +297,7 @@
 				y1 = $(this).prop('y1').animVal.value;
 				x2 = $(this).prop('x2').animVal.value;
 				y2 = $(this).prop('y2').animVal.value;
+				doorId = $(this).prop('id');
 
 				$.each(dataStore.paths[mapNum], function (index, path) {
 					if (floor.id === path.floor && ((path.ax === x1 && path.ay === y1) || (path.ax === x2 && path.ay === y2))) {


### PR DESCRIPTION
In separating things out, I inadvertently broke door processing. I didn't catch it because I had it cached on my end. Lesson learned!

The other (more verbose) commit in this pull request moves location pin drawing into its own function, to facilitate the placement of pins in locations other than the start point (e.g. at the endpoint, or maybe places of interest)
