### PR TITLE
Performance improvements, SVG compatibility improvements

### DIFF
--- a/src/jquery.wayfinding.js
+++ b/src/jquery.wayfinding.js
@@ -657,7 +657,7 @@
 			var cssH = $(cssDiv).height();
 
 			// Step 1, determine the scale
-			var scale = Math.max(( viewW / w ), ( viewH / h ));
+			var scale = Math.min(( viewW / w ), ( viewH / h ));
 
 			$(cssDiv).panzoom('zoom', parseFloat(scale));
 


### PR DESCRIPTION
Only animate zoom out for the last floor (the only one the user sees) to improve performance. Avoid initializing jQuery.panzoom on switchFloor and simply initialize it for every floor during plugin init.

Disable pointer-events for all elements in SVGs except '#Rooms a'. Helps greatly with Illustrator SVG exports changing frequently.
