### PR TITLE
Replace display: none with opacity: 0 on data layer (if it exists).

### DIFF
--- a/src/jquery.wayfinding.js
+++ b/src/jquery.wayfinding.js
@@ -63,7 +63,7 @@
 		},
 		'pinchToZoom': false, // requires jquery.panzoom
 		'zoomToRoute': true,
-		'zoomPadding': 85,
+		'zoomPadding': 25,
 		// milliseconds to wait during animation when a floor change occurs
 		'floorChangeAnimationDelay': 1250
 	};
@@ -278,6 +278,15 @@
 			$('#Paths line', svgDiv).attr('stroke-opacity', 0);
 			$('#Doors line', svgDiv).attr('stroke-opacity', 0);
 			$('#Portals line', svgDiv).attr('stroke-opacity', 0);
+
+			// If #Paths, #Doors, etc. are in a group, ensure that group does _not_
+			// have display: none; (commonly set by Illustrator when hiding a layer)
+			// and instead add opacity: 0; (which allows for events, unlike display: none;)
+			// (A group tag 'g' is used by Illustrator for layers.)
+			var $dataGroup = $('#Paths', svgDiv).parent();
+			if($dataGroup.is("g")) {
+				$dataGroup.attr('opacity', 0).attr('display', 'inline');
+			}
 
 			// The following need to use the el variable to scope their calls: el is jquery element
 


### PR DESCRIPTION
Hiding the data layer in Illustrator commonly sets display: none instead of opacity: 0 for the corresponding SVG group. This causes events to fail entirely on the data layer.

If the data groups exist in a layer together, ensure that layer is using opacity: 0, not display: none.

This reduces a step during the Illustrator SVG export and allows us to not have to hand-edit the SVG after export.
